### PR TITLE
bugfix RcppML::nmf + fgsea error message

### DIFF
--- a/R/pathwayAnalisys.R
+++ b/R/pathwayAnalisys.R
@@ -192,8 +192,8 @@ runScGSEA <- function(data,geneID,species,category,subcategory=NULL,pathway.list
         if (data$dimPCA<nmf.k || data$pca$use.odgenes) {
           tsmessage("... Performing NMF",verbose=verbose)
           tmp = RcppML::nmf(data$gficf,k=nmf.k)
-          data$scgsea$nmf.w <- Matrix::Matrix(data = tmp@w,sparse = T)
-          data$scgsea$nmf.h <- t(Matrix::Matrix(data = tmp@h,sparse = T))
+          data$scgsea$nmf.w <- Matrix::Matrix(data = tmp$w,sparse = T)
+          data$scgsea$nmf.h <- t(Matrix::Matrix(data = tmp$h,sparse = T))
           rm(tmp);gc()
         } else {
           tsmessage(paste0("Found NMF reduction with k greaten or equal to ", nmf.k),verbose=T)

--- a/R/pathwayAnalisys.R
+++ b/R/pathwayAnalisys.R
@@ -244,7 +244,8 @@ runScGSEA <- function(data,geneID,species,category,subcategory=NULL,pathway.list
   data$scgsea$nes = Matrix::Matrix(data = 0,nrow = length(data$scgsea$pathways),ncol = ncol(data$scgsea$nmf.w))
   data$scgsea$pval = Matrix::Matrix(data = 0,nrow = length(data$scgsea$pathways),ncol = ncol(data$scgsea$nmf.w))
   data$scgsea$fdr = Matrix::Matrix(data = 0,nrow = length(data$scgsea$pathways),ncol = ncol(data$scgsea$nmf.w))
-    
+  
+  rownames(data$scgsea$nmf.w) <- rownames(data$rawCounts)
   rownames(data$scgsea$es) = rownames(data$scgsea$nes) = rownames(data$scgsea$pval) = rownames(data$scgsea$fdr) = names(data$scgsea$pathways)
   
   tsmessage("Performing GSEA...",verbose=verbose)

--- a/R/pathwayAnalisys.R
+++ b/R/pathwayAnalisys.R
@@ -206,15 +206,15 @@ runScGSEA <- function(data,geneID,species,category,subcategory=NULL,pathway.list
       } else {
         tsmessage("... Performing NMF",verbose=verbose)
         tmp = RcppML::nmf(data$gficf,k=nmf.k)
-        data$scgsea$nmf.w <- Matrix::Matrix(data = tmp@w,sparse = T)
-        data$scgsea$nmf.h <- t(Matrix::Matrix(data = tmp@h,sparse = T))
+        data$scgsea$nmf.w <- Matrix::Matrix(data = tmp$w,sparse = T)
+        data$scgsea$nmf.h <- t(Matrix::Matrix(data = tmp$h,sparse = T))
         rm(tmp);gc()
       }
     } else {
       tsmessage("... Performing NMF",verbose=verbose)
       tmp = RcppML::nmf(log1p(data$rawCounts),k=nmf.k)
-      data$scgsea$nmf.w <- Matrix::Matrix(data = tmp@w,sparse = T)
-      data$scgsea$nmf.h <- t(Matrix::Matrix(data = tmp@h,sparse = T))
+      data$scgsea$nmf.w <- Matrix::Matrix(data = tmp$w,sparse = T)
+      data$scgsea$nmf.h <- t(Matrix::Matrix(data = tmp$h,sparse = T))
       rm(tmp);gc()
     }
   } else {

--- a/R/pathwayAnalisys.R
+++ b/R/pathwayAnalisys.R
@@ -191,7 +191,7 @@ runScGSEA <- function(data,geneID,species,category,subcategory=NULL,pathway.list
       if (!is.null(data$pca) && data$pca$type == "NMF"){
         if (data$dimPCA<nmf.k || data$pca$use.odgenes) {
           tsmessage("... Performing NMF",verbose=verbose)
-          tmp = RcppML::nmf(data = data$gficf,k=nmf.k)
+          tmp = RcppML::nmf(data$gficf,k=nmf.k)
           data$scgsea$nmf.w <- Matrix::Matrix(data = tmp@w,sparse = T)
           data$scgsea$nmf.h <- t(Matrix::Matrix(data = tmp@h,sparse = T))
           rm(tmp);gc()
@@ -205,14 +205,14 @@ runScGSEA <- function(data,geneID,species,category,subcategory=NULL,pathway.list
         }
       } else {
         tsmessage("... Performing NMF",verbose=verbose)
-        tmp = RcppML::nmf(data = data$gficf,k=nmf.k)
+        tmp = RcppML::nmf(data$gficf,k=nmf.k)
         data$scgsea$nmf.w <- Matrix::Matrix(data = tmp@w,sparse = T)
         data$scgsea$nmf.h <- t(Matrix::Matrix(data = tmp@h,sparse = T))
         rm(tmp);gc()
       }
     } else {
       tsmessage("... Performing NMF",verbose=verbose)
-      tmp = RcppML::nmf(data = log1p(data$rawCounts),k=nmf.k)
+      tmp = RcppML::nmf(log1p(data$rawCounts),k=nmf.k)
       data$scgsea$nmf.w <- Matrix::Matrix(data = tmp@w,sparse = T)
       data$scgsea$nmf.h <- t(Matrix::Matrix(data = tmp@h,sparse = T))
       rm(tmp);gc()


### PR DESCRIPTION
Hey guys,

regarding this issue:
https://github.com/dibbelab/gficf/issues/6#issue-1579102256

I fixed the RcppML::nmf function so that the keyword argument is not refuted by Rcpp. (Lines 194, 208, 215)

Further, RcppML::nmf returns a list, which is why I changed the code to $ accession compared to @. (following the RcppML::nmf function call)

Running runScGSEA with this prompted an error with a custom pathway list where fgsea said "stats should be named" (https://rdrr.io/bioc/fgsea/src/R/fgsea.R), which could be resolved by adding rownames that I took from the rawCounts slot. 


I tested the changes with a custom set of genes in my custom dataset as well as with the hallmarks on my custom dataset, both worked fine.


Thank you very much for the package!

